### PR TITLE
New Algorithm - Margins

### DIFF
--- a/main.htm
+++ b/main.htm
@@ -83,6 +83,7 @@ Algorithm:
 <option value=linescan.js title="Algorithm by J-Waal">Linescan</option>
 <option value=woven.js title="Algorithm by J-Waal">Woven</option>
 <option value=peano.js title="Algorithm by J-Waal">Peano</option>
+<option value=margins.js title="Algorithm by labusaid">Margins</option>
 </select>
 <img id=buffering src=loading.gif style='vertical-align:middle; display:inline-block; visibility:hidden;'>
 </form>

--- a/margins.js
+++ b/margins.js
@@ -15,20 +15,47 @@ onmessage = function(e) {
   const w=config.width, h=config.height;
   let output=[]
 
-  let n=0
-  while (n<config.Squiggles) {
+  function computeEdgeMap(pixData, w, h) {
+    const edgeMap = new Array(w * h).fill(0);
+    for (let y = 1; y < h - 1; y++) {
+      for (let x = 1; x < w - 1; x++) {
+        // Simple gradient magnitude (Sobel-like)
+        const i = y * w + x;
+        const gx = (
+          -getPixel(x-1, y-1) - 2*getPixel(x-1, y) - getPixel(x-1, y+1) +
+          getPixel(x+1, y-1) + 2*getPixel(x+1, y) + getPixel(x+1, y+1)
+        );
+        const gy = (
+          -getPixel(x-1, y-1) - 2*getPixel(x, y-1) - getPixel(x+1, y-1) +
+          getPixel(x-1, y+1) + 2*getPixel(x, y+1) + getPixel(x+1, y+1)
+        );
+        edgeMap[i] = Math.sqrt(gx*gx + gy*gy);
+      }
+    }
+    return edgeMap;
+  }
 
-    let x = Math.floor(Math.random()*w), y = Math.floor(Math.random()*h);
-    let z= getPixel(x,y)
-    let angle = 1-((z/255)*Math.PI*2),
-    // cos = Math.cos(angle) * (z/255) * config['Max Length'],
-    // sin = Math.sin(angle) * (z/255) * config['Max Length'],
-    cos = Math.cos(angle) * config['Max Length'],
-    sin = Math.sin(angle) * config['Max Length'];
+  const edgeMap = computeEdgeMap(pixData, w, h);
 
-    output.push([[x+cos,y+sin],[x-cos,y-sin]])
-    n++
-    
+  // Calculate grid size to evenly distribute squiggles
+  const gridSize = Math.sqrt((w * h) / config.Squiggles) | 0;
+  for (let y = gridSize; y < h - gridSize; y += gridSize) {
+    for (let x = gridSize; x < w - gridSize; x += gridSize) {
+      let i = y * w + x;
+      let edgeStrength = edgeMap[i];
+
+      // Map edge strength to length: strong edge = short, weak edge = long
+      // Normalize edgeStrength to [0,1] using a reasonable max (e.g., 255)
+      let normEdge = Math.min(edgeStrength / 255, 1);
+      let length = config['Max Length'] * (1 - normEdge * 0.9); // 0.1x length at max edge
+
+      let z = getPixel(x, y);
+      let angle = 1 - ((z / 255) * Math.PI * 2),
+          cos = Math.cos(angle) * length,
+          sin = Math.sin(angle) * length;
+
+      output.push([[x + cos, y + sin], [x - cos, y - sin]]);
+    }
   }
 
   if (config['Optimize route']) {
@@ -39,4 +66,3 @@ onmessage = function(e) {
   postLines(output)
   postMessage(['msg', "Done"]);
 }
-

--- a/margins.js
+++ b/margins.js
@@ -1,0 +1,42 @@
+importScripts('helpers.js')
+
+postMessage(['sliders', defaultControls.concat([
+  {label: 'Squiggles', value: 100, min: 100, max: 10000},
+  {label: 'Max Length', value: 5, min: 0.1, max: 40, step: 0.1},
+  {label: 'Threshold', value: 50, min: 1, max: 254},
+  {label: 'Optimize route', type:'checkbox', checked:true},
+])]);
+
+
+onmessage = function(e) {
+  const [ config, pixData ] = e.data;
+  const getPixel = pixelProcessor(config, pixData)
+
+  const w=config.width, h=config.height;
+  let output=[]
+
+  let n=0
+  while (n<config.Squiggles) {
+
+    let x = Math.floor(Math.random()*w), y = Math.floor(Math.random()*h);
+    let z= getPixel(x,y)
+    let angle = 1-((z/255)*Math.PI*2),
+    // cos = Math.cos(angle) * (z/255) * config['Max Length'],
+    // sin = Math.sin(angle) * (z/255) * config['Max Length'],
+    cos = Math.cos(angle) * config['Max Length'],
+    sin = Math.sin(angle) * config['Max Length'];
+
+    output.push([[x+cos,y+sin],[x-cos,y-sin]])
+    n++
+    
+  }
+
+  if (config['Optimize route']) {
+    postMessage(['msg', "Optimizing..."]);
+    output = sortlines(output)
+  }
+
+  postLines(output)
+  postMessage(['msg', "Done"]);
+}
+

--- a/margins.js
+++ b/margins.js
@@ -45,16 +45,29 @@ onmessage = function(e) {
       let edgeStrength = edgeMap[i];
 
       // Map edge strength to length: strong edge = short, weak edge = long
-      // Normalize edgeStrength to [0,1] using a reasonable max (e.g., 255)
       let normEdge = Math.min(edgeStrength / 255, 1);
       let length = config['Max Length'] * (1 - normEdge * 0.9); // 0.1x length at max edge
 
-      let z = getPixel(x, y);
-      let angle = 1 - ((z / 255) * Math.PI * 2),
-          cos = Math.cos(angle) * length,
-          sin = Math.sin(angle) * length;
+      // Map edge strength to arc angle: strong edge = more curved
+      // Arc angle from 10° (weak edge) to 120° (strong edge)
+      let minArc = Math.PI / 18;   // 10 degrees
+      let maxArc = Math.PI * 2 / 3; // 120 degrees
+      let arcAngle = minArc + (maxArc - minArc) * normEdge;
 
-      output.push([[x + cos, y + sin], [x - cos, y - sin]]);
+      // Orienation
+      let baseAngle = (edgeStrength/255) * Math.PI * 2;
+
+      // Arc center is at (x, y)
+      let points = [];
+      let numPoints = 5;
+      for (let j = 0; j < numPoints; j++) {
+        let t = j / (numPoints - 1); // 0..1
+        let theta = baseAngle - arcAngle / 2 + arcAngle * t;
+        let px = x + Math.cos(theta) * length;
+        let py = y + Math.sin(theta) * length;
+        points.push([px, py]);
+      }
+      output.push(points);
     }
   }
 

--- a/margins.js
+++ b/margins.js
@@ -3,8 +3,8 @@ importScripts('helpers.js')
 postMessage(['sliders', defaultControls.concat([
   {label: 'Squiggles', value: 2000, min: 500, max: 25000},
   {label: 'Max Length', value: 10, min: 0.1, max: 40, step: 0.1},
-  {label: 'Edge Detection', type:'checkbox', checked:true},
-  {label: 'Optimize route', type:'checkbox', checked:true},
+  {label: 'Edge Detection', type:'checkbox', checked:false},
+  {label: 'Optimize route', type:'checkbox', checked:false},
 ])]);
 
 

--- a/margins.js
+++ b/margins.js
@@ -5,7 +5,7 @@ postMessage(['sliders', defaultControls.concat([
   {label: 'Max Length', value: 10, min: 0.1, max: 20, step: 0.1},
   {label: 'Min Arc', value: 10, min: 0, max: 180, step: 5},         // degrees
   {label: 'Max Arc', value: 120, min: 0, max: 180, step: 5},      // degrees
-  {label: 'Rotation Factor', value: 0, min: -1, max: 1, step: 0.1},
+  {label: 'Rotation Factor', value: .5, min: -1, max: 1, step: 0.1},
   {label: 'Optimize route', type:'checkbox', checked:false},
 ])]);
 


### PR DESCRIPTION
Added a new algorithm inspired by the stuff I would fill the margins of my lecture notes with. Open to changing the name if something more descriptive in preferred.

Uses arcs with varying curvature and rotation to create an image. Both of these can be isolated with the provided sliders and still be effective.

Example:
<img width="400" height="400" alt="plotterfun-margins-beetle" src="https://github.com/user-attachments/assets/33c300e0-12d5-4e86-bded-7506c742a092" />
